### PR TITLE
Build and publish docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,27 @@ jobs:
 
       - name: Execute Gradle build
         run: ./gradlew build
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Execute Gradle build
+        run: ./gradlew jib

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Changelog
   * Updated github actions
   * Add feature to revoke objects that TA0 knows off, but are not requested
     (e.g. leftover files on manifest).
+  * Publish docker image `ripencc/rpki-ta-0`
 
 ### 0.3.5:
   * Removed explicit license from all files.

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,18 @@ distributions {
 }
 
 jib {
-    from { image = "eclipse-temurin:17-jammy" }
+    from {
+      image = "eclipse-temurin:17-jammy"
+      platforms {
+        platform {
+          architecture = 'amd64'
+          os = 'linux'
+        }
+        platform {
+          architecture = 'arm64'
+          os = 'linux'
+        }
+      }
+    }
     to { image = "ripencc/rpki-ta-0" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'jacoco'
     id 'io.freefair.lombok' version '6.5.1'
     id 'org.sonarqube' version '3.4.0.2513'
+    id 'com.google.cloud.tools.jib' version '3.3.0'
 }
 
 repositories {
@@ -109,4 +110,9 @@ distributions {
       }
     }
   }
+}
+
+jib {
+    from { image = "eclipse-temurin:17-jammy" }
+    to { image = "ripencc/rpki-ta-0" }
 }


### PR DESCRIPTION
  * [x] I have updated the changelog in README.md

Produces multi-platform images for amd64 and arm64. Pushes to docker hub `ripencc/rpki-ta-0`.